### PR TITLE
Handling comment search

### DIFF
--- a/Data/RowlogApi.py
+++ b/Data/RowlogApi.py
@@ -1,8 +1,8 @@
 import requests
 
 # accepts orderyBy = time, real_meters, scored_meters, or avg_heartrate.  Only returns desc, reverse the response for asc (see: Service.ErgMetersPerDay.py)
-def getWorkoutData(orderBy):
-    url = 'https://quikfo.com/rowlog/api/workouts?orderBy=' + orderBy
+def getWorkoutData(orderBy, comment):
+    url = 'https://quikfo.com/rowlog/api/workouts?orderBy=' + orderBy + '&comment=' + comment
     response = requests.get(url)
     return response.json()
 

--- a/main.py
+++ b/main.py
@@ -15,18 +15,18 @@ def ergMetersPerDay():
     from Core.Activities import Activities
     from Data.RowlogApi import getWorkoutData
     from Service import ErgMetersPerDay
-    return ErgMetersPerDay.run(getWorkoutData(orderBy='time'), Activities, DateParser)
+    return ErgMetersPerDay.run(getWorkoutData(orderBy='time', comment=''), Activities, DateParser)
 
 def typesOfWorkoutsPerPerson():
     from Core.Activities import Activities
     from Data.RowlogApi import getWorkoutData
     from Service import TypesOfWorkoutsPerPerson
-    return TypesOfWorkoutsPerPerson.run(getWorkoutData(orderBy='wid'), Activities)
+    return TypesOfWorkoutsPerPerson.run(getWorkoutData(orderBy='wid', comment=''), Activities)
 
 def workoutsPerPerson():
     from Data.RowlogApi import getWorkoutData
     from Service import WorkoutsPerPerson
-    return WorkoutsPerPerson.run(getWorkoutData(orderBy='wid'))
+    return WorkoutsPerPerson.run(getWorkoutData(orderBy='wid', comment=''))
  
 switcher = {
     'invalidService': invalidService,


### PR DESCRIPTION
## Description
@taddyb @TommyBurda 
as requested, `getWorkoutData` now accepts a comment parameter.
This operates using SQL's `LIKE` operator, so it won't look for exact matches, it will look for non-case sensitive substrings.  For example if you put in `Core` it will return, among other things, a workout with the comment `SS + warmup and core`.

## Testing
I ran a smoke test of two services after making these changes and all seems good to me.