### PR TITLE
Percent of meters fix

### DIFF
--- a/Service/PercentOfMeters.py
+++ b/Service/PercentOfMeters.py
@@ -4,20 +4,24 @@ def getNameToDataDict(peopleData):
         nameToData[ppl['name']] = ppl
     return nameToData
 
-def numOfWork(workoutsData Activites, nameToData):
+def numOfWork(workoutsData, Activites, nameToData):
     numOfWork = {}
-    for name in nameToData.items():
+    test = 0
+    for name, person in nameToData.items():
         numOfWork[name] = {}
-
-    for activity in Activites:
-        if (activity.name not in numOfWork[name].keys()):
-            numOfWork[name][activity.name] = {}
+        for activity in Activites:
+            if (activity.name not in numOfWork[name].keys()):
+                numOfWork[name][activity.name] = {}
+                if (activity.name in numOfWork[name].keys()):
+                    numOfWork[name][activity.name]['NumberOfWorkouts'] = test
+                    numOfWork[name][activity.name]['PercentageOfWork'] = test
     return numOfWork
 
-def precentOfMeters(peopleData, getWorkoutData, Activities):
+
+def percentOfMeters(peopleData, getWorkoutData, Activities):
     nameToData = getNameToDataDict(peopleData)
     myDict = {}
-    myDict['name'] = numOfWork(getWorkoutData, Activites, nameToData)
+    myDict['name'] = numOfWork(getWorkoutData, Activities, nameToData)
     return myDict
 
 def run(peopleData, getWorkoutData, Activities):

--- a/Service/PercentOfMeters.py
+++ b/Service/PercentOfMeters.py
@@ -5,7 +5,7 @@ def getNameToDataDict(peopleData):
     return nameToData
 
 
-def getDisplay(workoutsData, Activites, nameToData, types):
+def getDisplay(workoutsData, Activites, nameToData):
     numOfWork = {}
     total = 0
 
@@ -14,6 +14,8 @@ def getDisplay(workoutsData, Activites, nameToData, types):
         name = workout['name']
         if name not in numOfWork:
             numOfWork[name] = {}
+            numOfWork[name]['total'] = 0
+        numOfWork[name]['total'] += 1
         for activity in Activites:
             if (activity.name not in numOfWork[name].keys()):
                 numOfWork[name][activity.name] = {}
@@ -21,18 +23,17 @@ def getDisplay(workoutsData, Activites, nameToData, types):
                 numOfWork[name][activity.name]['PercentageOfWork'] = 0
             if type in activity.name:
                 numOfWork[name][activity.name]['NumberOfWorkouts'] += 1
-                numOfWork[name][activity.name]['PercentageOfWork'] = 100 * float(numOfWork[name][activity.name]['NumberOfWorkouts'])#/float()
+                numOfWork[name][activity.name]['PercentageOfWork'] = 100 * float(numOfWork[name][activity.name]['NumberOfWorkouts'])/float(numOfWork[name]['total'])
 
     return numOfWork
 
 #100 * float(numWork)/float(total)
 
-def percentOfMeters(peopleData, getWorkoutData, Activities, types):
+def percentOfMeters(peopleData, getWorkoutData, Activities):
     nameToData = getNameToDataDict(peopleData)
-    #per = percent(types)
     myDict = {}
-    myDict['name'] = getDisplay(getWorkoutData, Activities, nameToData, types)
+    myDict['name'] = getDisplay(getWorkoutData, Activities, nameToData)
     return myDict
 
-def run(peopleData, getWorkoutData, Activities, typesOfWorkoutsPerPerson):
-    return percentOfMeters(peopleData, getWorkoutData, Activities, typesOfWorkoutsPerPerson)
+def run(peopleData, getWorkoutData, Activities):
+    return percentOfMeters(peopleData, getWorkoutData, Activities)

--- a/Service/PercentOfMeters.py
+++ b/Service/PercentOfMeters.py
@@ -7,28 +7,25 @@ def getNameToDataDict(peopleData):
 
 def getDisplay(workoutsData, Activites, nameToData, types):
     numOfWork = {}
+    total = 0
 
     for workout in workoutsData:
         type = workout['type']
-
-
-    for name, person in nameToData.items():
-        numOfWork[name] = {}
+        name = workout['name']
+        if name not in numOfWork:
+            numOfWork[name] = {}
         for activity in Activites:
             if (activity.name not in numOfWork[name].keys()):
                 numOfWork[name][activity.name] = {}
-                if (activity.name in numOfWork[name].keys()):
-                        numOfWork[name][activity.name]['NumberOfWorkouts'] += 1
-                        numOfWork[name][activity.name]['PercentageOfWork'] = 0
+                numOfWork[name][activity.name]['NumberOfWorkouts'] = 0
+                numOfWork[name][activity.name]['PercentageOfWork'] = 0
+            if type in activity.name:
+                numOfWork[name][activity.name]['NumberOfWorkouts'] += 1
+                numOfWork[name][activity.name]['PercentageOfWork'] = 100 * float(numOfWork[name][activity.name]['NumberOfWorkouts'])#/float()
 
     return numOfWork
 
-#def percent(types):#numWork):
-#    for meters in types:
-#        total = meters['total_scored_meters']
-#        if(total == 0):
-#            return 0
-##            return total #100 * float(numWork)/float(total)
+#100 * float(numWork)/float(total)
 
 def percentOfMeters(peopleData, getWorkoutData, Activities, types):
     nameToData = getNameToDataDict(peopleData)

--- a/Service/PercentOfMeters.py
+++ b/Service/PercentOfMeters.py
@@ -7,7 +7,6 @@ def getNameToDataDict(peopleData):
 
 def getDisplay(workoutsData, Activites, nameToData):
     numOfWork = {}
-    total = 0
 
     for workout in workoutsData:
         type = workout['type']
@@ -23,11 +22,9 @@ def getDisplay(workoutsData, Activites, nameToData):
                 numOfWork[name][activity.name]['PercentageOfWork'] = 0
             if type in activity.name:
                 numOfWork[name][activity.name]['NumberOfWorkouts'] += 1
-                numOfWork[name][activity.name]['PercentageOfWork'] = 100 * float(numOfWork[name][activity.name]['NumberOfWorkouts'])/float(numOfWork[name]['total'])
+                numOfWork[name][activity.name]['PercentageOfWork'] = round(100 * float(numOfWork[name][activity.name]['NumberOfWorkouts'])/float(numOfWork[name]['total']), 2)
 
     return numOfWork
-
-#100 * float(numWork)/float(total)
 
 def percentOfMeters(peopleData, getWorkoutData, Activities):
     nameToData = getNameToDataDict(peopleData)

--- a/Service/PercentOfMeters.py
+++ b/Service/PercentOfMeters.py
@@ -1,13 +1,10 @@
-def getNameToDataDict(peopleData):
-    nameToData = {}
-    for ppl in peopleData:
-        nameToData[ppl['name']] = ppl
-    return nameToData
-
 def calcPercentOfWork(numOfWork, name, activity):
-    return round(100 * float(numOfWork[name][activity.name]['NumberOfWorkouts'])/float(numOfWork[name]['total']), 2)
+    num = numOfWork[name][activity.name]['NumberOfWorkouts']
+    tot = numOfWork[name]['total']
+    #print(num, tot)
+    return round((100 * float(num)/float(tot)), 2)
 
-def getDisplay(workoutsData, Activites, nameToData):
+def getDisplay(workoutsData, Activites):
     numOfWork = {}
     for workout in workoutsData:
         type = workout['type']
@@ -18,20 +15,19 @@ def getDisplay(workoutsData, Activites, nameToData):
         numOfWork[name]['total'] += 1
         for activity in Activites:
             active = activity.name
-            if (active not in numOfWork[name].keys()):
+            if active not in numOfWork[name].keys():
                 numOfWork[name][active] = {}
                 numOfWork[name][active]['NumberOfWorkouts'] = 0
                 numOfWork[name][active]['PercentageOfWork'] = 0
             if type in active:
                 numOfWork[name][active]['NumberOfWorkouts'] += 1
-                numOfWork[name][active]['PercentageOfWork'] = calcPercentOfWork(numOfWork, name, activity)
+            numOfWork[name][active]['PercentageOfWork'] = calcPercentOfWork(numOfWork, name, activity)
     return numOfWork
 
-def percentOfMeters(peopleData, getWorkoutData, Activities):
-    nameToData = getNameToDataDict(peopleData)
+def percentOfMeters(getWorkoutData, Activities):
     myDict = {}
-    myDict['name'] = getDisplay(getWorkoutData, Activities, nameToData)
+    myDict['name'] = getDisplay(getWorkoutData, Activities)
     return myDict
 
-def run(peopleData, getWorkoutData, Activities):
-    return percentOfMeters(peopleData, getWorkoutData, Activities)
+def run(getWorkoutData, Activities):
+    return percentOfMeters(getWorkoutData, Activities)

--- a/Service/PercentOfMeters.py
+++ b/Service/PercentOfMeters.py
@@ -1,0 +1,24 @@
+def getNameToDataDict(peopleData):
+    nameToData = {}
+    for ppl in peopleData:
+        nameToData[ppl['name']] = ppl
+    return nameToData
+
+def numOfWork(workoutsData Activites, nameToData):
+    numOfWork = {}
+    for name in nameToData.items():
+        numOfWork[name] = {}
+        
+    for activity in Activites:
+        if (activity.name not in numOfWork[name].keys()):
+            numOfWork[name][activity.name] = {}
+    return numOfWork
+
+def precentOfMeters(peopleData, getWorkoutData, Activities):
+    nameToData = getNameToDataDict(peopleData)
+    myDict = {}
+    myDict['name'] = numOfWork(getWorkoutData, Activites, nameToData)
+    return myDict
+
+def run(peopleData, getWorkoutData, Activities):
+    return percentOfMeters(peopleData, getWorkoutData, Activities)

--- a/Service/PercentOfMeters.py
+++ b/Service/PercentOfMeters.py
@@ -4,25 +4,40 @@ def getNameToDataDict(peopleData):
         nameToData[ppl['name']] = ppl
     return nameToData
 
-def numOfWork(workoutsData, Activites, nameToData):
+
+def getDisplay(workoutsData, Activites, nameToData, types):
     numOfWork = {}
-    test = 0
+
+    for workout in workoutsData:
+        type = workout['type']
+
+
     for name, person in nameToData.items():
         numOfWork[name] = {}
         for activity in Activites:
             if (activity.name not in numOfWork[name].keys()):
                 numOfWork[name][activity.name] = {}
                 if (activity.name in numOfWork[name].keys()):
-                    numOfWork[name][activity.name]['NumberOfWorkouts'] = test
-                    numOfWork[name][activity.name]['PercentageOfWork'] = test
+                    for work in types:
+                        if work in activity.name:
+                            numOfWork[name][activity.name]['NumberOfWorkouts'] += 1
+                            numOfWork[name][activity.name]['PercentageOfWork'] = 0
+
     return numOfWork
 
+#def percent(types):#numWork):
+#    for meters in types:
+#        total = meters['total_scored_meters']
+#        if(total == 0):
+#            return 0
+##            return total #100 * float(numWork)/float(total)
 
-def percentOfMeters(peopleData, getWorkoutData, Activities):
+def percentOfMeters(peopleData, getWorkoutData, Activities, types):
     nameToData = getNameToDataDict(peopleData)
+    #per = percent(types)
     myDict = {}
-    myDict['name'] = numOfWork(getWorkoutData, Activities, nameToData)
+    myDict['name'] = getDisplay(getWorkoutData, Activities, nameToData, types)
     return myDict
 
-def run(peopleData, getWorkoutData, Activities):
-    return percentOfMeters(peopleData, getWorkoutData, Activities)
+def run(peopleData, getWorkoutData, Activities, typesOfWorkoutsPerPerson):
+    return percentOfMeters(peopleData, getWorkoutData, Activities, typesOfWorkoutsPerPerson)

--- a/Service/PercentOfMeters.py
+++ b/Service/PercentOfMeters.py
@@ -4,10 +4,11 @@ def getNameToDataDict(peopleData):
         nameToData[ppl['name']] = ppl
     return nameToData
 
+def calcPercentOfWork(numOfWork, name, activity):
+    return round(100 * float(numOfWork[name][activity.name]['NumberOfWorkouts'])/float(numOfWork[name]['total']), 2)
 
 def getDisplay(workoutsData, Activites, nameToData):
     numOfWork = {}
-
     for workout in workoutsData:
         type = workout['type']
         name = workout['name']
@@ -16,14 +17,14 @@ def getDisplay(workoutsData, Activites, nameToData):
             numOfWork[name]['total'] = 0
         numOfWork[name]['total'] += 1
         for activity in Activites:
-            if (activity.name not in numOfWork[name].keys()):
-                numOfWork[name][activity.name] = {}
-                numOfWork[name][activity.name]['NumberOfWorkouts'] = 0
-                numOfWork[name][activity.name]['PercentageOfWork'] = 0
-            if type in activity.name:
-                numOfWork[name][activity.name]['NumberOfWorkouts'] += 1
-                numOfWork[name][activity.name]['PercentageOfWork'] = round(100 * float(numOfWork[name][activity.name]['NumberOfWorkouts'])/float(numOfWork[name]['total']), 2)
-
+            active = activity.name
+            if (active not in numOfWork[name].keys()):
+                numOfWork[name][active] = {}
+                numOfWork[name][active]['NumberOfWorkouts'] = 0
+                numOfWork[name][active]['PercentageOfWork'] = 0
+            if type in active:
+                numOfWork[name][active]['NumberOfWorkouts'] += 1
+                numOfWork[name][active]['PercentageOfWork'] = calcPercentOfWork(numOfWork, name, activity)
     return numOfWork
 
 def percentOfMeters(peopleData, getWorkoutData, Activities):

--- a/Service/PercentOfMeters.py
+++ b/Service/PercentOfMeters.py
@@ -1,7 +1,6 @@
 def calcPercentOfWork(numOfWork, name, activity):
     num = numOfWork[name][activity.name]['NumberOfWorkouts']
     tot = numOfWork[name]['total']
-    #print(num, tot)
     return round((100 * float(num)/float(tot)), 2)
 
 def getDisplay(workoutsData, Activites):

--- a/main.py
+++ b/main.py
@@ -31,6 +31,17 @@ def typesOfWorkoutsPerPerson(args):
     from Service import TypesOfWorkoutsPerPerson
     return TypesOfWorkoutsPerPerson.run(getWorkoutData(), Activities)
 
+def workoutsPerPerson(args):
+    from Data.RowlogApi import getWorkoutData
+    from Service import WorkoutsPerPerson
+    return WorkoutsPerPerson.run(getWorkoutData(orderBy='wid', comment=''))
+
+def totalMetersPerSide(args):
+    from Data.RowlogApi import getWorkoutData
+    from Data.RowlogApi import getPeopleData
+    from Service import TotalMetersPerSide
+    return TotalMetersPerSide.run(getWorkoutData(orderBy='wid', comment=''), getPeopleData())
+
 def percentOfMeters():
     from Core.Activites import Activities
     from Data.RowlogApi import getWorkoutData
@@ -45,15 +56,11 @@ switcher = {
     'totalMetersPerSide': totalMetersPerSide,
     'typesOfWorkoutsPerPerson': typesOfWorkoutsPerPerson,
     'percentOfMeters': percentOfMeters,
-    'invalidService': invalidService
 }
 
-def serviceSwitch(argument):
-    service = switcher.get(argument, invalidService)
-    try:
-        return service()
-    except:
-        return 'Error occurred'
+def serviceSwitch(arguments):
+    service = switcher.get(arguments[1], invalidService)
+    return service(arguments)
 
 output = serviceSwitch(parseInput())
 print(json.dumps(output))

--- a/main.py
+++ b/main.py
@@ -46,8 +46,9 @@ def percentOfMeters(args):
     from Core.Activities import Activities
     from Data.RowlogApi import getWorkoutData
     from Data.RowlogApi import getPeopleData
+    from Service.TypesOfWorkoutsPerPerson import getTypesOfWorkoutsPerPerson
     from Service import PercentOfMeters
-    return PercentOfMeters.run(getPeopleData(), getWorkoutData(orderBy='wid', comment=''), Activities)
+    return PercentOfMeters.run(getPeopleData(), getWorkoutData(orderBy='wid', comment=''), Activities, getTypesOfWorkoutsPerPerson)
 
 switcher = {
     'ergMetersPerDay': ergMetersPerDay,

--- a/main.py
+++ b/main.py
@@ -20,13 +20,21 @@ def typesOfWorkoutsPerPerson():
     from Data.RowlogApi import getWorkoutData
     from Service import TypesOfWorkoutsPerPerson
     return TypesOfWorkoutsPerPerson.run(getWorkoutData(), Activities)
- 
+
+def percentOfMeters():
+    from Core.Activites import Activities
+    from Data.RowlogApi import getWorkoutData
+    from Data.RowlogApi import getPeopleData
+    from Service import PercentOfMeters
+    return PercentOfMeters.run(getPeopleData(), getWorkoutData(), Activities)
+
 switcher = {
     'workoutsPerPerson': workoutsPerPerson,
     'typesOfWorkoutsPerPerson': typesOfWorkoutsPerPerson,
+    'percentOfMeters': percentOfMeters,
     'invalidService': invalidService
 }
- 
+
 def serviceSwitch(argument):
     service = switcher.get(argument, invalidService)
     try:

--- a/main.py
+++ b/main.py
@@ -42,12 +42,12 @@ def totalMetersPerSide(args):
     from Service import TotalMetersPerSide
     return TotalMetersPerSide.run(getWorkoutData(orderBy='wid', comment=''), getPeopleData())
 
-def percentOfMeters():
-    from Core.Activites import Activities
+def percentOfMeters(args):
+    from Core.Activities import Activities
     from Data.RowlogApi import getWorkoutData
     from Data.RowlogApi import getPeopleData
     from Service import PercentOfMeters
-    return PercentOfMeters.run(getPeopleData(), getWorkoutData(), Activities)
+    return PercentOfMeters.run(getPeopleData(), getWorkoutData(orderBy='wid', comment=''), Activities)
 
 switcher = {
     'ergMetersPerDay': ergMetersPerDay,

--- a/main.py
+++ b/main.py
@@ -67,9 +67,8 @@ def totalMetersPerSide(args):
 def percentOfMeters(args):
     from Core.Activities import Activities
     from Data.RowlogApi import getWorkoutData
-    from Data.RowlogApi import getPeopleData
     from Service import PercentOfMeters
-    return PercentOfMeters.run(getPeopleData(teamCode=args[1]), getWorkoutData(teamCode=args[1], orderBy='wid', comment=''), Activities)
+    return PercentOfMeters.run(getWorkoutData(teamCode=args[1], orderBy='wid', comment=''), Activities)
 
 def averageMetersAndSplitBySide(args):
     from Data.RowlogApi import getWorkoutData

--- a/main.py
+++ b/main.py
@@ -70,9 +70,9 @@ def percentOfMeters(args):
     from Core.Activities import Activities
     from Data.RowlogApi import getWorkoutData
     from Data.RowlogApi import getPeopleData
-    from Service.TypesOfWorkoutsPerPerson import getTypesOfWorkoutsPerPerson
+    from Service import TypesOfWorkoutsPerPerson
     from Service import PercentOfMeters
-    return PercentOfMeters.run(getPeopleData(), getWorkoutData(orderBy='wid', comment=''), Activities, getTypesOfWorkoutsPerPerson)
+    return PercentOfMeters.run(getPeopleData(teamCode=args[1]), getWorkoutData(teamCode=args[1], orderBy='wid', comment=''), Activities, TypesOfWorkoutsPerPerson)
 
 def averageMetersAndSplitBySide(args):
     from Data.RowlogApi import getWorkoutData

--- a/main.py
+++ b/main.py
@@ -41,7 +41,6 @@ def typesOfWorkoutsPerPerson(args):
     from Service import TypesOfWorkoutsPerPerson
     return TypesOfWorkoutsPerPerson.run(getWorkoutData(teamCode=args[1], orderBy='wid', comment=''), Activities)
 
-
 def totalMetersPerSide(args):
     from Data.RowlogApi import getWorkoutData
     from Data.RowlogApi import getPeopleData
@@ -65,7 +64,6 @@ def totalMetersPerSide(args):
     from Service import TotalMetersPerSide
     return TotalMetersPerSide.run(getWorkoutData(teamCode=args[1], orderBy='wid', comment=''), getPeopleData(teamCode=args[1]))
 
-
 def percentOfMeters(args):
     from Core.Activities import Activities
     from Data.RowlogApi import getWorkoutData
@@ -87,10 +85,11 @@ switcher = {
     'invalidService': invalidService,
     'individualContributions': individualContributions,
     'longestWorkoutPerDay': longestWorkoutPerDay,
+    'percentOfMeters': percentOfMeters,
     'searchComments': searchComments,
     'totalMetersPerSide': totalMetersPerSide,
     'typesOfWorkoutsPerPerson': typesOfWorkoutsPerPerson,
-    'percentOfMeters': percentOfMeters,
+    'workoutsPerPerson': workoutsPerPerson
 }
 
 def serviceSwitch(arguments):

--- a/main.py
+++ b/main.py
@@ -70,9 +70,8 @@ def percentOfMeters(args):
     from Core.Activities import Activities
     from Data.RowlogApi import getWorkoutData
     from Data.RowlogApi import getPeopleData
-    from Service import TypesOfWorkoutsPerPerson
     from Service import PercentOfMeters
-    return PercentOfMeters.run(getPeopleData(teamCode=args[1]), getWorkoutData(teamCode=args[1], orderBy='wid', comment=''), Activities, TypesOfWorkoutsPerPerson)
+    return PercentOfMeters.run(getPeopleData(teamCode=args[1]), getWorkoutData(teamCode=args[1], orderBy='wid', comment=''), Activities)
 
 def averageMetersAndSplitBySide(args):
     from Data.RowlogApi import getWorkoutData


### PR DESCRIPTION
- This pull request is for a fix to the following service, it should now output the correct percentOfWork:

- "This service will return:
A dictionary that holds everyone's names, a total which totals all the workouts they have done, a dictionary inside of the names dictionary with the different workouts. This workouts dictionary holds all the names of the different workouts. This then tracks the number of individual workouts each athlete has done, and the percentage of that specific workout based on all the other workouts that athlete has done."

-This code has been tested and outputs the proper percentOfWork in this format
`{"name": {"Kevin Brown": {"total": 11, "Erg": {"NumberOfWorkouts": 4, "PercentageOfWork": 36.36}, "Bike": {"NumberOfWorkouts": 0, "PercentageOfWork": 0.0}, "Run": {"NumberOfWorkouts": 1, "PercentageOfWork": 9.09}, "Swim": {"NumberOfWorkouts": 0, "PercentageOfWork": 0.0}, "Lift": {"NumberOfWorkouts": 4, "PercentageOfWork": 36.36}, "Core": {"NumberOfWorkouts": 2, "PercentageOfWork": 18.18}}`

- I have also cleaned up the program a bit more. Pulled out some "useless" code that had not been used