### PR TITLE
Adding charts framework

### DIFF
--- a/charts/Core/ChartConfig.py
+++ b/charts/Core/ChartConfig.py
@@ -1,0 +1,30 @@
+class ChartConfig:
+    def __init__(self, type, options):
+        self.type = type
+        self.data = {
+            'data': [],
+            'labels': []
+        }
+        self.options = options
+
+    def addDataset(self, dataset):
+        self.data['data'].append(dataset)
+
+    def setXAxesData(self, xAxesPoints):
+        self.data['labels'] = xAxesPoints
+
+    def __jsonifyData(self):
+        jsonifiedDatasets = []
+        for dataset in self.data['data']:
+            jsonifiedDatasets.append(dataset.toJson())
+        return {'data': jsonifiedDatasets}
+
+    def toJson(self):
+        return {
+            "type": self.type,
+            "options": self.options.toJson(),
+            "data": {
+                "labels": self.data['labels'],
+                "datasets": self.__jsonifyData()
+            }
+        }

--- a/charts/Core/ChartData.py
+++ b/charts/Core/ChartData.py
@@ -1,0 +1,32 @@
+class ChartDataset:
+
+    def __init__(self):
+        self.label = 'Default'
+        self.data = []
+        self.backgroundColor = []
+        self.borderColor = []
+        self.borderWidth = 1
+
+    def setLabel(self, label):
+        self.label = label
+
+    def addData(self, data):
+        self.data.append(data)
+
+    def addBackgroundColor(self, color):
+        self.backgroundColor.append(color)
+
+    def addBorderColor(self, color):
+        self.borderColor.append(color)
+
+    def setBorderWidth(self, width):
+        self.borderWidth = width
+
+    def toJson(self):
+        return {
+            "label": self.label,
+            "data": self.data,
+            "backgroundColor": self.backgroundColor,
+            "borderColor": self.borderColor,
+            "borderWidth": self.borderWidth,
+        }

--- a/charts/Core/ChartOptions.py
+++ b/charts/Core/ChartOptions.py
@@ -1,0 +1,31 @@
+class ChartOptions:
+    def __init__(self):
+        self.responsive = True
+        self.title = {
+            "display": True,
+            "text": "Select an Item in the Legend to Include it on the Chart"
+        }
+        self.tooltips = {
+            "mode": "nearest",
+            "intersect": False
+        }
+        self.hover = {
+            "mode": "nearest",
+            "intersect": "false"
+        }
+        self.scales = {
+            'yAxes': [{
+                'ticks': {
+                    'beginAtZero': True
+                }
+            }]
+        }
+
+    def toJson(self):
+        return {
+            "responsive": self.responsive,
+            "title": self.title,
+            "tooltips": self.tooltips,
+            "hover": self.hover,
+            "scales": self.scales
+        }

--- a/charts/Core/ColorHelper.py
+++ b/charts/Core/ColorHelper.py
@@ -1,0 +1,7 @@
+def generateRandomRgbaColor(transparency):
+    from random import randint
+    r = randint(0, 255)
+    g = randint(0, 255)
+    b = randint(0, 255)
+    a = transparency
+    return 'rgba({}, {}, {}, {})'.format(r, g, b, a)

--- a/charts/Core/CustomEncoder.py
+++ b/charts/Core/CustomEncoder.py
@@ -1,0 +1,16 @@
+class CustomEncoder(json.JSONEncoder):
+
+    def default(self, obj):
+        if isinstance(obj, ChartConfig):
+            return {
+                "type": obj.type,
+                "data": obj.data,
+                "options": default(self, obj.options)
+            }
+        if isinstance(obj, ChartData):
+            return {
+                "type": obj.type,
+                "data": obj.data,
+                "options": default(self, obj.options)
+            }
+        return json.JSONEncoder.default(self, obj)

--- a/charts/IndividualContributions/IndividualContributions.py
+++ b/charts/IndividualContributions/IndividualContributions.py
@@ -1,0 +1,40 @@
+import random
+
+def getDaysFromUniversalAvg(data):
+    days = []
+    for key in data.keys():
+        days.append(key)
+    return days
+
+def populateDataset(dataset, data, xs, ColorHelper):
+    for x in xs:
+        if x in data.keys():
+            dataset.addData(data[x])
+        else:
+            dataset.addData(0)
+    color = ColorHelper.generateRandomRgbaColor(0.8)
+    dataset.addBackgroundColor(color)
+    dataset.addBorderColor(color)
+    return dataset
+
+def formatData(ChartConfig, ChartOptions, ChartDataset, data, ColorHelper):
+    chartOptions = ChartOptions()
+    chartConfig = ChartConfig('line', chartOptions)
+    xs = getDaysFromUniversalAvg(data["universalAvg_metersPerDay"])
+    chartConfig.setXAxesData(xs)
+    keys = [
+        "universalAvg_metersPerDay",
+        "1v_metersPerDayPerPerson",
+        "2v_metersPerDayPerPerson",
+        "3v_metersPerDayPerPerson",
+        "4v+_metersPerDayPerPerson"
+    ]
+    for key in keys:
+        dataset = ChartDataset()
+        dataset.setLabel(key)
+        chartConfig.addDataset(populateDataset(dataset, data[key], xs, ColorHelper))
+    for person in data['byPerson_metersPerDay']:
+        dataset = ChartDataset()
+        dataset.setLabel(person)
+        chartConfig.addDataset(populateDataset(dataset, data['byPerson_metersPerDay'][person], xs, ColorHelper))
+    return chartConfig.toJson()

--- a/charts/api.py
+++ b/charts/api.py
@@ -1,0 +1,31 @@
+import json
+import flask
+import requests
+from flask import request, jsonify
+
+from Core.ChartConfig import ChartConfig
+from Core.ChartOptions import ChartOptions
+from Core.ChartData import ChartDataset
+
+app = flask.Flask(__name__)
+app.config["DEBUG"] = True
+
+def getService(teamCode, service):
+    url = 'https://rows.tech/api/analysis?teamCode=' + str(teamCode) + '&service=' + str(service)
+    return json.loads(requests.get(url).text)
+
+@app.route('/', methods=['GET'])
+def home():
+    return 'Charts api is running!'
+
+@app.route('/individualContributions', methods=['GET'])
+def individualContributions():
+    from IndividualContributions import IndividualContributions
+    from Core import ColorHelper
+    teamCode = request.args.get('teamCode')
+    service = 'individualContributions'
+    data = getService(teamCode, service)
+    return IndividualContributions.formatData(ChartConfig, ChartOptions, ChartDataset, data, ColorHelper)
+
+if __name__ == '__main__':
+    app.run()


### PR DESCRIPTION
There's still some cleanup for me to do on these files so bear with me.

The classes `ChartConfig`, `ChartOptions`, and `ChartDataset` are going to be the key components of a chart service.  `ChartConfig.data` is a list of `ChartDataset` instances, `ChartConfig.options` is a `ChartOptions` instance.  Simply return your completed `ChartConfig` to create output usable by our FE framework, chartjs.

The main parts to use as examples here are in `api.py` and `individualContributions.py` -- think of `api.py` as you did `main.py` in our analysis services -- it should be the container for endpoint -> service routing.  Then you should create separate files for service specific logic, like is the case in `individualContributions.py`.  I got the ball rolling with a helper script in `Core` as well with `ColorHelper` -- use this to generate random colors for datasets.

I still need to add the logic to allow `ChartOptions` to be more configurable, but it should be ok for now.

Testing is live at https://rows.tech/api/charts/individualContributions -- be sure to include a `teamCode` url parameter if you want to see relevant data via this endpoint.
@taddyb @kiikoh @cc12698 @ChrisLaibach @Logar18 @JordanIrving @Will-Holt1 @mitchell3301 